### PR TITLE
Changing ng2 to ngx rebranding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# ng2-openmrs-formbuilder
+# ngx-openmrs-formbuilder
 
 This is a tool that builds OpenMRS Form Schemas interactively.
 This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 1.2.1.
 
 ## Development
 
-Run `git clone https://github.com/AMPATH/ng2-openmrs-formbuilder.git` to clone the repo locally.
+Run `git clone https://github.com/openmrs/ngx-openmrs-formbuilder.git` to clone the repo locally.
 
-Run `cd ng2-openmrs-formbuilder`
+Run `cd ngx-openmrs-formbuilder`
 
 Run `npm install` to install dependencies.
 
@@ -30,9 +30,9 @@ Then `npm start` for a dev server. Navigate to `http://localhost:4200/`. The app
 - (docker)[https://docs.docker.com/engine/install/]
 - (docker-compose)[https://docs.docker.com/compose/install/]
 
-Run `git clone https://github.com/AMPATH/ng2-openmrs-formbuilder.git` to clone the repo locally.
+Run `git clone https://github.com/openmrs/ngx-openmrs-formbuilder.git` to clone the repo locally.
 
-Run `docker build -t ng2-openmrs-formbuilder .` (don't forget the fullstop at the end)
+Run `docker build -t ngx-openmrs-formbuilder .` (don't forget the fullstop at the end)
 
 Run `export OPENMRS_HOST_URL=http://172.17.0.1`
 

--- a/src/app/Services/element-editor.service.ts
+++ b/src/app/Services/element-editor.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Subject } from 'rxjs';
+
 @Injectable()
 export class ElementEditorService {
   private previouslySelectAnswers: Subject<Object> = new Subject();

--- a/src/app/Services/openmrs-api/encounter-type.service.ts
+++ b/src/app/Services/openmrs-api/encounter-type.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { SessionStorageService } from '../storage/session-storage.service';
 import { Constants } from '../constants';
 import { HttpClient } from '@angular/common/http';
+
 @Injectable()
 export class EncounterTypeService {
   private baseUrl: string;

--- a/src/app/Services/openmrs-api/fetch-all-forms.service.ts
+++ b/src/app/Services/openmrs-api/fetch-all-forms.service.ts
@@ -7,6 +7,7 @@ import { FetchFormDetailService } from '../openmrs-api/fetch-form-detail.service
 import { LocalStorageService } from '../storage/local-storage.service';
 import { BehaviorSubject } from 'rxjs';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
+
 @Injectable()
 export class FetchAllFormsService {
   private headers = new HttpHeaders();

--- a/src/app/Services/openmrs-api/location-resource.service.ts
+++ b/src/app/Services/openmrs-api/location-resource.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@angular/core';
 import { SessionStorageService } from '../storage/session-storage.service';
 import { AuthenticationService } from '../authentication/authentication.service';
 import { HttpClient } from '@angular/common/http';
+
 @Injectable()
 export class LocationResourceService {
   private baseUrl: string;

--- a/src/app/Services/openmrs-api/patient-resource.service.ts
+++ b/src/app/Services/openmrs-api/patient-resource.service.ts
@@ -5,6 +5,7 @@ import { SessionStorageService } from '../storage/session-storage.service';
 import { AuthenticationService } from '../authentication/authentication.service';
 import { Observable } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
+
 @Injectable()
 export class PatientResourceService {
   private credentials: any;

--- a/src/app/Services/order.service.ts
+++ b/src/app/Services/order.service.ts
@@ -10,6 +10,7 @@ interface ConceptUuid {
   uuid: string;
   conceptDetails: any;
 }
+
 @Injectable()
 export class OrderService {
   private data: any = {};

--- a/src/app/Services/question-control.service.ts
+++ b/src/app/Services/question-control.service.ts
@@ -9,6 +9,7 @@ import {
   Validators
 } from '@angular/forms';
 import { ALL_PROPERTIES, Properties } from '../form-editor/models/properties';
+
 @Injectable()
 export class QuestionControlService {
   propertyModels: any = [];

--- a/src/app/Services/question-id.service.ts
+++ b/src/app/Services/question-id.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import * as _ from 'lodash';
+
 @Injectable()
 export class QuestionIdService {
   private IDs = [];

--- a/src/app/Services/route-guards/save-forms-guard.service.ts
+++ b/src/app/Services/route-guards/save-forms-guard.service.ts
@@ -8,6 +8,7 @@ import { FormEditorComponent } from '../../form-editor/form-editor/form-editor.c
 import { ConfirmComponent } from '../../modals/confirm.component';
 import { Observable } from 'rxjs';
 import { Router } from '@angular/router';
+
 @Injectable()
 export class SaveFormsGuardService
   implements CanDeactivate<FormEditorComponent> {

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -8,6 +8,7 @@ import { SaveFormsGuardService } from './Services/route-guards/save-forms-guard.
 import { AuthGuardService } from './Services/route-guards/auth-guard.service';
 import { UpdateFormsComponent } from './form-editor/update-forms/update-forms.component';
 import { UpdateFormsWizardComponent } from './form-editor/update-forms-wizard/update-forms-wizard.component';
+
 const appRoutes: Routes = [
   { path: '', redirectTo: 'forms', pathMatch: 'full' },
   { path: 'login', component: LoginComponent },


### PR DESCRIPTION
cc @brandones @ibacher .
This fix is based on using current renaming from ng2 to ngx. Basically  , ng2 and ngx are one and means the same, However ngx is the current new name, so we would also rename all of our readme files to the current renaming. Thanks.